### PR TITLE
The mainQueueReachability method returns a singleton

### DIFF
--- a/SGVReachability.xcodeproj/project.pbxproj
+++ b/SGVReachability.xcodeproj/project.pbxproj
@@ -49,7 +49,10 @@
 				BB49E32617490EB900552133 /* Frameworks */,
 				BB49E32517490EB900552133 /* Products */,
 			);
+			indentWidth = 4;
 			sourceTree = "<group>";
+			tabWidth = 4;
+			usesTabs = 0;
 		};
 		BB49E32517490EB900552133 /* Products */ = {
 			isa = PBXGroup;

--- a/src/SGVReachability.m
+++ b/src/SGVReachability.m
@@ -105,7 +105,12 @@ static NSString * const kSGVReachabilityFlagsAccessQueueNameTemplate = @"com.san
 #pragma mark - public
 
 + (instancetype)mainQueueReachability {
-    return [[self alloc] initWithNotificationsQueue:[NSOperationQueue mainQueue]];
+    static SGVReachability *mainQueueReachability;
+    static dispatch_once_t once;
+    dispatch_once(&once, ^{
+        mainQueueReachability = [[self alloc] initWithNotificationsQueue:[NSOperationQueue mainQueue]];
+    });
+    return mainQueueReachability;
 }
 
 #pragma mark - private

--- a/src/SGVReachability.m
+++ b/src/SGVReachability.m
@@ -184,7 +184,7 @@ static void SGVReachabilityChangedCallback(SCNetworkReachabilityRef target,
 #pragma mark - properties
 
 - (SCNetworkReachabilityFlags)flags {
-    __block SCNetworkReachabilityFlags resultFlags;
+    __block SCNetworkReachabilityFlags resultFlags = (SCNetworkReachabilityFlags)0;
     [self isReachableWithCheckBlock:^BOOL(SCNetworkReachabilityFlags flags) {
         resultFlags = flags;
         return YES;

--- a/src/SGVReachability.m
+++ b/src/SGVReachability.m
@@ -113,7 +113,7 @@ static NSString * const kSGVReachabilityFlagsAccessQueueNameTemplate = @"com.san
 static void SGVReachabilityChangedCallback(SCNetworkReachabilityRef target,
                                            SCNetworkReachabilityFlags flags,
                                            void* info) {
-	SGVReachability* reachability = (__bridge SGVReachability *)info;
+    SGVReachability* reachability = (__bridge SGVReachability *)info;
     [reachability updateFlagsFromFlags:flags];
     void (^notificationBlock)(void) = ^{
         [[NSNotificationCenter defaultCenter] postNotificationName:SGVReachabilityChangedNotification


### PR DESCRIPTION
This avoids unnecessary cleaning in dealloc.

Also a small fix to silence the static analyzer warnings.
